### PR TITLE
Add react v15.0 version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "^3.3.0",
     "mocha": "^2.3.3",
     "proxyquire": "^1.7.3",
-    "react": "^0.14.6",
+    "react": "^0.14.2 || ^15.0.0",
     "sinon": "^1.17.1"
   },
   "devDependencies": {


### PR DESCRIPTION
@jmcriffey i _think_ this is causing react 15.0 and above not to be able to install
